### PR TITLE
Viewer: fix some inheritance issues

### DIFF
--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -236,7 +236,7 @@ export class ViewerHotSpotResult {
     public visibility: number = NaN;
 }
 
-type Model = IDisposable &
+export type Model = IDisposable &
     Readonly<{
         assetContainer: AssetContainer;
         materialVariantsController: Nullable<MaterialVariantsController>;

--- a/packages/tools/viewer-alpha/src/viewerAnnotationElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerAnnotationElement.ts
@@ -42,10 +42,14 @@ export class HTML3DAnnotationElement extends LitElement {
     public hotSpot: string = "";
 
     /** @internal */
-    public override connectedCallback(): void {
+    public override async connectedCallback(): Promise<void> {
         super.connectedCallback();
         this._internals.states?.add("invalid");
 
+        // Sometimes override parent element is not defined yet.
+        if (this.parentElement?.matches(":not(:defined)")) {
+            await customElements.whenDefined(this.parentElement?.tagName.toLowerCase());
+        }
         if (!(this.parentElement instanceof ViewerElement)) {
             // eslint-disable-next-line no-console
             console.warn("The babylon-viewer-annotation element must be a child of a babylon-viewer element.");

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-internal-modules
 import type { ArcRotateCamera, Nullable, Observable } from "core/index";
 
-import type { PropertyValues, TemplateResult } from "lit";
+import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import type { EnvironmentOptions, ToneMapping, ViewerDetails, ViewerHotSpotQuery } from "./viewer";
 import type { CanvasViewerOptions } from "./viewerFactory";
 
@@ -160,7 +160,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
 
     /** @internal */
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    public static override styles = css`
+    public static override styles: CSSResultGroup = css`
         :host {
             --ui-foreground-color: white;
             --ui-background-hue: 233;

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -53,7 +53,7 @@ function parseColor(color: string | null | undefined): Nullable<Color4> {
 type HotSpot = ViewerHotSpotQuery & { cameraOrbit?: [alpha: number, beta: number, radius: number] };
 
 // Custom events for the HTML3DElement.
-interface ViewerElementEventMap extends HTMLElementEventMap {
+export interface ViewerElementEventMap extends HTMLElementEventMap {
     viewerready: Event;
     viewerrender: Event;
     environmentchange: Event;
@@ -953,7 +953,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
         super.addEventListener(type as string, listener as EventListenerOrEventListenerObject, options as boolean | AddEventListenerOptions);
     }
 
-    private _dispatchCustomEvent<TEvent extends keyof ViewerElementEventMap>(type: TEvent, event: (type: TEvent) => ViewerElementEventMap[TEvent]) {
+    protected _dispatchCustomEvent<TEvent extends keyof ViewerElementEventMap>(type: TEvent, event: (type: TEvent) => ViewerElementEventMap[TEvent]) {
         this.dispatchEvent(event(type));
     }
 


### PR DESCRIPTION
Export the `Model` type to define the return type for the `loadAnotherModel` function.
Expose custom events interface and dispatching function.
In `HTML3DAnnotationElement` wait for the parent to be defined before testing it.